### PR TITLE
Fix CRON environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM phusion/passenger-customizable:2.3.1
 
 ENV RAILS_ENV production
 
+RUN usermod -a -G docker_env app
+
 RUN apt-get -q update
 RUN apt-get -qy -o Dpkg::Options::="--force-confold" upgrade
 RUN echo 'postfix postfix/mailname string opensnp.org' | debconf-set-selections


### PR DESCRIPTION
CRON seems to only be able to access the environment variables if given access to `/etc/container_environment*`. This is necessary for the rake tasks run by CRON to be able to do their jobs. Herewith, we shall grant access by adding the  `app` user to the `docker_env` group. ✍️